### PR TITLE
Improve handling of quality with perfectionist trait

### DIFF
--- a/1.5/Source/VanillaTraitsExpanded/HarmonyPatches/GenerateQualityCreatedByPawn_Patch.cs
+++ b/1.5/Source/VanillaTraitsExpanded/HarmonyPatches/GenerateQualityCreatedByPawn_Patch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using RimWorld;
 using System;
+using System.Linq;
 using Verse;
 
 
@@ -17,6 +18,7 @@ namespace VanillaTraitsExpanded
 			0,
 			0
 		})]
+	[HarmonyPriority(Priority.First)]
 	public static class GenerateQualityCreatedByPawn_Patch
 	{
 		private static void Prefix(Pawn pawn, out bool __state)
@@ -39,6 +41,12 @@ namespace VanillaTraitsExpanded
 					var newResult = (QualityCategory)((int)__result + 1);
 					__result = newResult;
 				}
+				else
+				{
+					// Allow legendary items if the current quality
+					// was already legendary, even without inspiration.
+					__state = true;
+				}
 				if (__result == QualityCategory.Normal || __result == QualityCategory.Awful || __result == QualityCategory.Poor)
 				{
 					pawn.TryGiveThought(VTEDefOf.VTE_CreatedLowQualityItem);
@@ -47,10 +55,10 @@ namespace VanillaTraitsExpanded
                 {
 					if (ModsConfig.IdeologyActive)
                     {
-						var role = pawn.Ideo.GetRole(pawn);
-						if (role != null && role.def.defName == "IdeoRole_ProductionSpecialist")
+						var effect = pawn.Ideo.GetRole(pawn)?.def.roleEffects.OfType<RoleEffect_ProductionQualityOffset>().FirstOrDefault();
+						if (effect != null && effect.offset > 0)
                         {
-							return; // we allow legendary for production specialist
+							return; // we allow legendary for any roles boosting production quality
                         }
                     }
 					__result = QualityCategory.Masterwork;


### PR DESCRIPTION
Fixes an issue where perfectionist would prevent "masterful craft" pawns from Ancients from crafting legendary items, along with some other improvements to compatibility with other mods doing the same.

- The quality patch received higher priority to make it run before most other mods modifying quality
- Perfectionist no longer lowers legendary item quality to masterful if increased by other sources and there's no inspiration/role for it
  - So if another mod runs a patch before this one and increases quality to legendary, we'll no longer lower it to masterwork
- Replace production specialist check with a check for a role having positive production quality offset
  - This should ensure other roles besides vanilla production specialist can boost item quality to legendary